### PR TITLE
Handle timeout

### DIFF
--- a/lib/nvp-request.js
+++ b/lib/nvp-request.js
@@ -59,6 +59,11 @@ NVPRequest.prototype.execute = function ( method, params, callback ){
     });
   });
 
+  req.on( 'timeout', function () {
+    req.socket.destroy();
+    callback(new Error('Request timeout'));
+  });
+
   req.write( body );
 
   req.on( 'error', function ( err ){


### PR DESCRIPTION
When doing a request to PayPal, it can time out, and we sometimes need to take action, e.g. in doExpressCheckPayment, where one must call getExpressCheckoutDetails to know the status of the payment.

The code is arguably a bit basic right now, but it does the job.
